### PR TITLE
Fixed bug with 'Open Cue' and browse '...' when saved path does not exist

### DIFF
--- a/src/net/oesterholt/pcutmp3gui/PCutMP3Gui.java
+++ b/src/net/oesterholt/pcutmp3gui/PCutMP3Gui.java
@@ -179,8 +179,9 @@ public class PCutMP3Gui extends Application
 	              //Set extension filter
 	              FileChooser.ExtensionFilter extFilter = new FileChooser.ExtensionFilter("MP3 Files (*.mp3)", "*.mp3");
 	              fileChooser.getExtensionFilters().add(extFilter);
-	              if (p.getCueLoc() != null) {
-	            	  fileChooser.setInitialDirectory(new File(p.getCueLoc()));
+	              File prefLoc = new File(p.getCueLoc());
+	              if (prefLoc.exists()) {
+	            	  fileChooser.setInitialDirectory(prefLoc);
 	              }
 	             
 	              //Show open file dialog
@@ -226,8 +227,9 @@ public class PCutMP3Gui extends Application
 	              //Set extension filter
 	              FileChooser.ExtensionFilter extFilter = new FileChooser.ExtensionFilter("CUE Files (*.cue)", "*.cue");
 	              fileChooser.getExtensionFilters().add(extFilter);
-	              if (p.getCueLoc() != null) {
-	            	  fileChooser.setInitialDirectory(new File(p.getCueLoc()));
+	              File prefLoc = new File(p.getCueLoc());
+	              if (prefLoc.exists()) {
+	            	  fileChooser.setInitialDirectory(prefLoc);
 	              }
 	             
 	              //Show open file dialog

--- a/src/net/oesterholt/pcutmp3gui/Prefs.java
+++ b/src/net/oesterholt/pcutmp3gui/Prefs.java
@@ -51,7 +51,7 @@ public class Prefs {
 	}
 	
 	public String getCueLoc() {
-		return _prefs.get("cueloc", null);
+		return _prefs.get("cueloc", "");
 	}
 	
 	public void setCueLoc(String l) {


### PR DESCRIPTION
This resolves the possibility of setting the initial directory of the file choosers to an invalid path.
A path saved in preferences can become invalid if a user deletes or moves the directory at the location described by the path.

This manifests as the 'Open Cue' and browse '...' buttons no longer showing a file chooser - rendering the button non-functional.
